### PR TITLE
SQLiteのバージョンアップのためxeus-sqliteを使う

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,10 @@
 title: Query Me
 author: BQ FUN
 
+# https://jupyterbook.org/content/execute.html
+execute:
+  execute_notebooks: force
+
 html:
   favicon: "favicon.ico"
   use_edit_page_button: true

--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - beakerx
-  - ipywidgets
+  - xeus-sqlite

--- a/notebooks.ipynb
+++ b/notebooks.ipynb
@@ -14,7 +14,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "%defaultDatasource jdbc:sqlite::memory:"
+    "%LOAD example.db"
    ],
    "metadata": {
     "collapsed": false,
@@ -56,28 +56,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sql",
-   "language": "sql",
-   "name": "sql"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.0"
-  },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "state": {},
-    "version_major": 2,
-    "version_minor": 0
-   }
+   "name": "xsqlite",
+   "language": "sqlite",
+   "display_name": "xsqlite"
   }
  },
  "nbformat": 4,

--- a/test_abe.ipynb
+++ b/test_abe.ipynb
@@ -14,7 +14,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "%defaultDatasource jdbc:sqlite::memory:"
+    "%LOAD example.db"
    ],
    "metadata": {
     "collapsed": false,
@@ -56,28 +56,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sql",
-   "language": "sql",
-   "name": "sql"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.0"
-  },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "state": {},
-    "version_major": 2,
-    "version_minor": 0
-   }
+   "name": "xsqlite",
+   "language": "sqlite",
+   "display_name": "xsqlite"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
beakerではバンドルされている3.21.0からアップデートするのに苦労しそうだったのでxeus-sqliteを使うように。